### PR TITLE
SIFTS map uniprot resnum to PDB function fix

### DIFF
--- a/ssbio/test/conftest.py
+++ b/ssbio/test/conftest.py
@@ -102,3 +102,10 @@ def pdb_ids_obsolete():
 @pytest.fixture(scope='module')
 def pdb_ids_false():
     return ['soda','meow','1984','pycharm']
+
+
+@pytest.fixture(scope='module')
+def sifts_xmls_working(test_files_structures):
+    """ SIFTS XML file for protein structure with non-A,B chains """
+    # ssbio/test/test_files/structures/1atp.sifts.xml
+    return op.join(test_files_structures, '1atp.sifts.xml')

--- a/ssbio/test/conftest.py
+++ b/ssbio/test/conftest.py
@@ -105,7 +105,7 @@ def pdb_ids_false():
 
 
 @pytest.fixture(scope='module')
-def sifts_xmls_working(test_files_structures):
+def sifts_xml(test_files_structures):
     """ SIFTS XML file for protein structure with non-A,B chains """
     # ssbio/test/test_files/structures/1atp.sifts.xml
     return op.join(test_files_structures, '1atp.sifts.xml')

--- a/ssbio/test/test_databases_pdb.py
+++ b/ssbio/test/test_databases_pdb.py
@@ -30,12 +30,12 @@ def test_download_sifts_xml(pdb_ids_working, pdb_ids_obsolete, pdb_ids_false, te
             pdb.download_sifts_xml(pdb_id=fp, outdir=test_files_tempdir, force_rerun=True)
 
 
-def test_map_uniprot_resnum_to_pdb(sifts_xmls_working):
+def test_map_uniprot_resnum_to_pdb(sifts_xml):
     mapping_cases = [
         # Tuple(inputs, expected_outputs)
-        ({'uniprot_resnum': 20, 'chain_id': 'I', 'sifts_file': sifts_xmls_working[0]}, (19, True)),
-        ({'uniprot_resnum': 20, 'chain_id': 'A', 'sifts_file': sifts_xmls_working[0]}, (False, None)),  # invalid chain
-        ({'uniprot_resnum': 999, 'chain_id': 'I', 'sifts_file': sifts_xmls_working[0]}, (False, None)),  # invalid res
+        ({'uniprot_resnum': 20, 'chain_id': 'I', 'sifts_file': sifts_xml}, (19, True)),
+        ({'uniprot_resnum': 20, 'chain_id': 'A', 'sifts_file': sifts_xml}, (None, False)),  # invalid chain
+        ({'uniprot_resnum': 999, 'chain_id': 'I', 'sifts_file': sifts_xml}, (None, False)),  # invalid res
     ]
     for inputs, outputs in mapping_cases:
         mapped_resnum, is_observed = pdb.map_uniprot_resnum_to_pdb(**inputs)

--- a/ssbio/test/test_databases_pdb.py
+++ b/ssbio/test/test_databases_pdb.py
@@ -16,6 +16,7 @@ def test_download_mmcif_header(pdb_ids_working, pdb_ids_obsolete, pdb_ids_false,
         with pytest.raises(URLError):
             pdb.download_mmcif_header(pdb_id=fp, outdir=test_files_tempdir, force_rerun=True)
 
+
 def test_download_sifts_xml(pdb_ids_working, pdb_ids_obsolete, pdb_ids_false, test_files_tempdir):
     for wp in pdb_ids_working:
         pdb.download_sifts_xml(pdb_id=wp, outdir=test_files_tempdir)
@@ -28,8 +29,18 @@ def test_download_sifts_xml(pdb_ids_working, pdb_ids_obsolete, pdb_ids_false, te
         with pytest.raises(URLError):
             pdb.download_sifts_xml(pdb_id=fp, outdir=test_files_tempdir, force_rerun=True)
 
-def test_map_uniprot_resnum_to_pdb(pdb_ids_working, pdb_ids_obsolete, pdb_ids_false, test_files_tempdir):
-    pass
+
+def test_map_uniprot_resnum_to_pdb(sifts_xmls_working):
+    mapping_cases = [
+        # Tuple(inputs, expected_outputs)
+        ({'uniprot_resnum': 20, 'chain_id': 'I', 'sifts_file': sifts_xmls_working[0]}, (19, True)),
+        ({'uniprot_resnum': 20, 'chain_id': 'A', 'sifts_file': sifts_xmls_working[0]}, (False, None)),  # invalid chain
+        ({'uniprot_resnum': 999, 'chain_id': 'I', 'sifts_file': sifts_xmls_working[0]}, (False, None)),  # invalid res
+    ]
+    for inputs, outputs in mapping_cases:
+        mapped_resnum, is_observed = pdb.map_uniprot_resnum_to_pdb(**inputs)
+        assert (mapped_resnum, is_observed) == outputs
+
 
 def test_best_structures(pdb_ids_working, pdb_ids_obsolete, pdb_ids_false, test_files_tempdir):
     pass

--- a/ssbio/test/test_files/structures/1atp.sifts.xml
+++ b/ssbio/test/test_files/structures/1atp.sifts.xml
@@ -1,0 +1,6219 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<entry xmlns:align="http://www.ebi.ac.uk/pdbe/docs/sifts/alignment.xsd" xmlns:data="http://www.ebi.ac.uk/pdbe/docs/sifts/dataTypes.xsd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ebi.ac.uk/pdbe/docs/sifts/eFamily.xsd" dbSource="PDBe" dbVersion="2.0" dbCoordSys="PDBe" dbAccessionId="1atp" dbEntryVersion="2019-08-14" date="2020-11-30" xsi:schemaLocation="http://www.ebi.ac.uk/pdbe/docs/sifts/eFamily.xsd http://www.ebi.ac.uk/pdbe/docs/sifts/eFamily.xsd">
+  <rdf:RDF>
+    <rdf:Description rdf:about="self">
+      <dc:rights rdf:resource="http://pdbe.org/sifts">
+        Copyright notice: (c) 2004-2020, EMBL-EBI, PDBe-UniProt
+        Jose M. Dana, Nidhi Tyagi, Preeti Choudhary, Aleksandras Gutmanas, Claire O'Donovan, Maria J. Martin, Sameer Velankar.
+        The information included is supplied as-is, under the terms and conditions of the licence agreement.
+        </dc:rights>
+    </rdf:Description>
+  </rdf:RDF>
+  <listDB>
+    <db dbSource="Pfam" dbCoordSys="UniProt" dbVersion="33.1"/>
+    <db dbSource="InterPro" dbCoordSys="PDBresnum" dbVersion="83.0"/>
+    <db dbSource="CATH" dbCoordSys="PDBresnum" dbVersion="4.2.0"/>
+    <db dbSource="EC" dbCoordSys="UniProt" dbVersion="48.20"/>
+    <db dbSource="SCOP2" dbCoordSys="PDBresnum" dbVersion="2020-11-26"/>
+    <db dbSource="UniProt" dbCoordSys="UniProt" dbVersion="2020.06"/>
+    <db dbSource="SCOP" dbCoordSys="PDBresnum" dbVersion="1.75"/>
+    <db dbSource="GO" dbCoordSys="UniProt" dbVersion="20201006"/>
+    <db dbSource="PDB" dbCoordSys="PDBresnum" dbVersion="48.20"/>
+  </listDB>
+  <entity type="protein" entityId="A">
+    <segment segId="1atp_A_1_350" start="1" end="350">
+      <listResidue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="1" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="2" dbResName="G"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="2" dbResName="G"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="2" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="2" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="3" dbResName="N"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="3" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="3" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="3" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="4" dbResName="A"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="4" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="4" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="4" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="5" dbResName="A"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="5" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="5" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="5" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="6" dbResName="A"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="6" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="6" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="6" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="7" dbResName="A"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="7" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="7" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="7" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="8" dbResName="K"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="8" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="8" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="8" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="9" dbResName="K"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="9" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="9" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="9" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="10" dbResName="G"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="10" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="10" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="10" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="11" dbResName="S"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="11" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="11" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="11" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="12" dbResName="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="12" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="12" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="12" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="13" dbResName="Q"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="13" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="13" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="13" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="14" dbResName="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="14" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="14" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="14" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="null" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="15" dbResName="S"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="null" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="15" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="null" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="15" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <residueDetail dbSource="PDBe" property="Annotation">Not_Observed</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="15" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="15" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="16" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="15" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="15" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="15" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="16" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="15" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="16" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="16" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="16" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="16" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="17" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="16" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="16" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="16" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="17" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="16" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="17" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="17" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="17" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="18" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="17" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="17" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="17" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="18" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="17" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="18" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="18" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="18" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="19" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="18" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="18" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="18" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="19" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="18" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="19" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="19" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="19" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="20" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="19" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="19" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="19" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="20" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="19" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="20" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="20" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="20" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="21" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="20" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="20" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="20" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="21" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="20" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="21" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="21" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="21" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="22" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="21" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="21" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="21" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="22" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="21" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="22" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="22" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="22" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="23" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="22" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="22" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="22" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="23" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="22" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="23" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="23" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="23" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="24" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="23" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="23" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="23" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="24" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="23" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="24" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="24" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="24" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="25" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="24" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="24" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="24" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="25" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="24" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="25" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="25" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="25" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="26" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="25" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="25" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="25" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="26" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="25" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="26" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="26" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="26" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="27" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="26" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="26" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="26" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="27" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="26" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="27" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="27" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="27" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="28" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="27" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="27" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="27" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="28" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="27" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="27" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="28" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="28" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="28" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="29" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="28" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="28" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="28" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="29" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="28" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="28" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="29" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="29" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="29" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="30" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="29" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="29" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="29" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="30" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="29" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="29" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="30" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="30" dbResName="TRP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="30" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="31" dbResName="W"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="30" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="30" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="30" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="31" dbResName="W"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="30" dbResName="TRP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="30" dbResName="TRP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="31" dbResName="W" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="31" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="31" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="32" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="31" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="31" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="31" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="32" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="31" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="31" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="32" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="32" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="32" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="33" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="32" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="32" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="32" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="33" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="32" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="32" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="33" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="33" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="33" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="34" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="33" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="33" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="33" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="34" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="33" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="33" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="34" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="34" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="34" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="35" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="34" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="34" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="34" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="35" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="34" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="34" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="35" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="35" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="35" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="36" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="35" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="35" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="35" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="36" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="35" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="35" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="36" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="36" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="36" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="37" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="36" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="36" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="36" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="37" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="36" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="36" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="37" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="37" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="37" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="38" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="37" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="37" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="37" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="38" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="37" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="37" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="38" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="38" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="38" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="39" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="38" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="38" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="38" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="39" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="38" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="38" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="39" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="39" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="39" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="40" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="39" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="39" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="39" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="40" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="39" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="39" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="40" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="40" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="40" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="41" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="40" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="40" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="40" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="41" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="40" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="40" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="41" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="41" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="41" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="42" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="41" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="41" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="41" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="42" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="41" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="41" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="42" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="42" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="42" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="43" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="42" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="42" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="42" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="43" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="42" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="42" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="43" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="43" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="43" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="44" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="44" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="43" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="43" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="43" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="44" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="43" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="43" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="43" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="44" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="44" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="44" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="45" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="45" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="44" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="44" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="44" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="45" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="44" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="44" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="44" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="44" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="45" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="45" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="45" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="46" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="46" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="45" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="45" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="45" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="46" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="45" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="45" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="45" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="45" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="46" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="46" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="46" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="47" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="47" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="46" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="46" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="46" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="47" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="46" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="46" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="46" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="46" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="47" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="47" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="47" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="48" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="48" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="47" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="47" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="47" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="48" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="47" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="47" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="47" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="47" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="48" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="48" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="48" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="49" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="49" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="48" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="48" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="48" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="49" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="48" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="48" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="48" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="48" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="49" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="49" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="49" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="50" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="50" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="49" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="49" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="49" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="50" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="49" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="49" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="49" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="49" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="50" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="50" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="50" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="51" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="51" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="50" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="50" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="50" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="51" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="50" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="50" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="50" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="50" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="51" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="51" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="51" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="52" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="52" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="51" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="51" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="51" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="52" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="51" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="51" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="51" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="51" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="52" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="52" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="52" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="53" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="53" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="52" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="52" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="52" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="53" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="52" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="52" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="52" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="52" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="53" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="53" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="53" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="54" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="54" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="53" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="53" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="53" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="54" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="53" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="53" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="53" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="53" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="54" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="54" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="54" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="55" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="55" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="54" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="54" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="54" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="55" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="54" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="54" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="54" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="54" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="55" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="55" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="55" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="56" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="56" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="55" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="55" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="55" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="56" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="55" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="55" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="55" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="55" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="56" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="56" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="56" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="57" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="57" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="56" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="56" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="56" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="57" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="56" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="56" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="56" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="56" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="57" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="57" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="57" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="58" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="58" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="57" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="57" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="57" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="58" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="57" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="57" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="57" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="57" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="58" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="58" dbResName="MET">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="58" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="59" dbResName="M"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="59" dbResName="M"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="58" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="58" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="58" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="59" dbResName="M"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="58" dbResName="MET" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="58" dbResName="MET" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="58" dbResName="MET" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="58" dbResName="MET" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="59" dbResName="M" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="59" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="59" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="60" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="60" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="59" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="59" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="59" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="60" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="59" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="59" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="59" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="59" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="60" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="60" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="60" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="61" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="61" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="60" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="60" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="60" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="61" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="60" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="60" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="60" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="60" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="61" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="61" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="61" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="62" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="62" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="61" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="61" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="61" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="62" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="61" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="61" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="61" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="61" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="62" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="62" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="62" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="63" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="63" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="62" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="62" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="62" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="63" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="62" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="62" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="62" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="62" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="63" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="63" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="63" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="64" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="64" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="63" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="63" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="63" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="64" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="63" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="63" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="63" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="63" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="64" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="64" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="64" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="65" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="65" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="64" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="64" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="64" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="65" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="64" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="64" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="64" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="64" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="65" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="65" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="65" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="66" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="66" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="65" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="65" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="65" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="66" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="65" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="65" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="65" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="65" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="66" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="66" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="66" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="67" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="67" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="66" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="66" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="66" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="67" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="66" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="66" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="66" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="66" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="67" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="67" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="67" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="68" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="68" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="67" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="67" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="67" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="68" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="67" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="67" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="67" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="67" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="68" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="68" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="68" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="69" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="69" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="68" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="68" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="68" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="69" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="68" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="68" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="68" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="68" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="69" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="69" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="69" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="70" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="70" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="69" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="69" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="69" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="70" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="69" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="69" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="69" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="69" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="70" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="70" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="70" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="71" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="71" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="70" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="70" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="70" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="71" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="70" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="70" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="70" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="70" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="71" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="71" dbResName="MET">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="71" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="72" dbResName="M"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="72" dbResName="M"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="71" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="71" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="71" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="72" dbResName="M"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="71" dbResName="MET" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="71" dbResName="MET" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="71" dbResName="MET" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="71" dbResName="MET" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="72" dbResName="M" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="72" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="72" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="73" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="73" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="72" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="72" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="72" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="73" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="72" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="72" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="72" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="72" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="73" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="73" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="73" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="74" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="74" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="73" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="73" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="73" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="74" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="73" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="73" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="73" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="73" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="74" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="74" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="74" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="75" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="75" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="74" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="74" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="74" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="75" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="74" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="74" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="74" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="74" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="75" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="75" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="75" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="76" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="76" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="75" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="75" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="75" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="76" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="75" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="75" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="75" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="75" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="76" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="76" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="76" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="77" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="77" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="76" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="76" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="76" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="77" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="76" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="76" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="76" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="76" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="77" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="77" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="77" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="78" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="78" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="77" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="77" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="77" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="78" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="77" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="77" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="77" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="77" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="78" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="78" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="78" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="79" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="79" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="78" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="78" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="78" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="79" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="78" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="78" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="78" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="78" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="79" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="79" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="79" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="80" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="80" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="79" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="79" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="79" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="80" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="79" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="79" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="79" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="79" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="80" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="80" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="80" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="81" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="81" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="80" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="80" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="80" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="81" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="80" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="80" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="80" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="80" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="81" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="81" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="81" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="82" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="82" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="81" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="81" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="81" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="82" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="81" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="81" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="81" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="81" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="82" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="82" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="82" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="83" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="83" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="82" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="82" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="82" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="83" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="82" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="82" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="82" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="82" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="83" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="83" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="83" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="84" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="84" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="83" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="83" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="83" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="84" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="83" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="83" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="83" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="83" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="84" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="84" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="84" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="85" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="85" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="84" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="84" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="84" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="85" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="84" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="84" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="84" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="84" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="85" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="85" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="85" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="86" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="86" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="85" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="85" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="85" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="86" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="85" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="85" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="85" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="85" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="86" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="86" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="86" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="87" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="87" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="86" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="86" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="86" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="87" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="86" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="86" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="86" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="86" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="87" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="87" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="87" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="88" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="88" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="87" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="87" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="87" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="88" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="87" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="87" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="87" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="87" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="88" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="88" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="88" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="89" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="89" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="88" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="88" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="88" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="89" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="88" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="88" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="88" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="88" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="89" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="89" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="89" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="90" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="90" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="89" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="89" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="89" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="90" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="89" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="89" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="89" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="89" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="90" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="90" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="90" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="91" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="91" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="90" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="90" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="90" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="91" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="90" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="90" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="90" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="90" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="91" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="91" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="91" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="92" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="92" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="91" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="91" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="91" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="92" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="91" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="91" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="91" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="91" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="92" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="92" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="92" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="93" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="93" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="92" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="92" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="92" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="93" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="92" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="92" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="92" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="92" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="93" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="93" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="93" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="94" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="94" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="93" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="93" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="93" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="94" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="93" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="93" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="93" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="93" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="94" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="94" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="94" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="95" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="95" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="94" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="94" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="94" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="95" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="94" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="94" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="94" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="94" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="95" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="95" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="95" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="96" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="96" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="95" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="95" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="95" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="96" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="95" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="95" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="95" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="95" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="96" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="96" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="96" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="97" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="97" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="96" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="96" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="96" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="97" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="96" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="96" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="96" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="96" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="97" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="97" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="97" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="98" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="98" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="97" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="97" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="97" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="98" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="97" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="97" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="97" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="97" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="98" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="98" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="98" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="99" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="99" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="98" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="98" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="98" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="99" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="98" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="98" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="98" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="98" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="99" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="99" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="99" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="100" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="100" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="99" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="99" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="99" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="100" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="99" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="99" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="99" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="99" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="100" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="100" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="100" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="101" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="101" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="100" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="100" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="100" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="101" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="100" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="100" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="100" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="100" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="101" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="101" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="101" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="102" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="102" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="101" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="101" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="101" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="102" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="101" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="101" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="101" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="101" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="102" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="102" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="102" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="103" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="103" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="102" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="102" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="102" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="103" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="102" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="102" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="102" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="102" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="103" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="103" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="103" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="104" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="104" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="103" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="103" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="103" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="104" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="103" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="103" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="103" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="103" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="104" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="104" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="104" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="105" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="105" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="104" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="104" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="104" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="105" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="104" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="104" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="104" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="104" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="105" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="105" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="105" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="106" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="106" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="105" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="105" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="105" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="106" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="105" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="105" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="105" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="105" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="106" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="106" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="106" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="107" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="107" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="106" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="106" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="106" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="107" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="106" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="106" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="106" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="106" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="107" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="107" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="107" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="108" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="108" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="107" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="107" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="107" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="108" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="107" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="107" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="107" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="107" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="108" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="108" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="108" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="109" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="109" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="108" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="108" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="108" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="109" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="108" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="108" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="108" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="108" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="109" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="109" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="109" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="110" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="110" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="109" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="109" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="109" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="110" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="109" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="109" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="109" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="109" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="110" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="110" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="110" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="111" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="111" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="110" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="110" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="110" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="111" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="110" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="110" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="110" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="110" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="111" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="111" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="111" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="112" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="112" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="111" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="111" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="111" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="112" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="111" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="111" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="111" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="111" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="112" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="112" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="112" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="113" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="113" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="112" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="112" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="112" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="113" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="112" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="112" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="112" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="112" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="113" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="113" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="113" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="114" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="114" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="113" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="113" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="113" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="114" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="113" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="113" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="113" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="113" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="114" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="114" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="114" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="115" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="115" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="114" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="114" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="114" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="115" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="114" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="114" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="114" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="114" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="115" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="115" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="115" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="116" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="116" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="115" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="115" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="115" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="116" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="115" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="115" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="115" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="115" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="116" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="116" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="116" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="117" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="117" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="116" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="116" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="116" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="117" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="116" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="116" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="116" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="116" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="117" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="117" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="117" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="118" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="118" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="117" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="117" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="117" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="118" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="117" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="117" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="117" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="117" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="118" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="118" dbResName="MET">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="118" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="119" dbResName="M"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="119" dbResName="M"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="118" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="118" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="118" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="119" dbResName="M"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="118" dbResName="MET" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="118" dbResName="MET" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="118" dbResName="MET" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="118" dbResName="MET" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="119" dbResName="M" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="119" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="119" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="120" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="120" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="119" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="119" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="119" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="120" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="119" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="119" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="119" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="119" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="120" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="120" dbResName="MET">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="120" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="121" dbResName="M"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="121" dbResName="M"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="120" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="120" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="120" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="121" dbResName="M"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="120" dbResName="MET" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="120" dbResName="MET" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="120" dbResName="MET" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="120" dbResName="MET" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="121" dbResName="M" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="121" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="121" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="122" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="122" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="121" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="121" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="121" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="122" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="121" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="121" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="121" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="121" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="122" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="122" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="122" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="123" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="123" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="122" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="122" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="122" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="123" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="122" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="122" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="122" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="122" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="123" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="123" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="123" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="124" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="124" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="123" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="123" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="123" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="124" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="123" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="123" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="123" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="123" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="124" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="124" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="124" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="125" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="125" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="124" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="124" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="124" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="125" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="124" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="124" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="124" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="124" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="125" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="125" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="125" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="126" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="126" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="125" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="125" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="125" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="126" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="125" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="125" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="125" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="125" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="126" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="126" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="126" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="127" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="127" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="126" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="126" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="126" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="127" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="126" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="126" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="126" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="126" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="127" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="127" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="127" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="128" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="128" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="127" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="127" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="127" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="128" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="127" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="127" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="127" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="127" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="128" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="128" dbResName="MET">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="128" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="129" dbResName="M"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="129" dbResName="M"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="128" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="128" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="128" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="129" dbResName="M"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="128" dbResName="MET" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="128" dbResName="MET" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="128" dbResName="MET" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="128" dbResName="MET" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="129" dbResName="M" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="129" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="129" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="130" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="130" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="129" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="129" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="129" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="130" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="129" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="129" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="129" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="129" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="130" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="130" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="130" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="131" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="131" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="130" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="130" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="130" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="131" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="130" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="130" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="130" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="130" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="131" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="131" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="131" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="132" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="132" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="131" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="131" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="131" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="132" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="131" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="131" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="131" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="131" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="132" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="132" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="132" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="133" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="133" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="132" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="132" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="132" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="133" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="132" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="132" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="132" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="132" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="133" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="133" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="133" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="134" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="134" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="133" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="133" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="133" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="134" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="133" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="133" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="133" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="133" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="134" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="134" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="134" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="135" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="135" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="134" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="134" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="134" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="135" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="134" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="134" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="134" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="134" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="135" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="135" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="135" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="136" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="136" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="135" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="135" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="135" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="136" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="135" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="135" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="135" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="135" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="136" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="136" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="136" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="137" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="137" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="136" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="136" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="136" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="137" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="136" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="136" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="136" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="136" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="137" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="137" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="137" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="138" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="138" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="137" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="137" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="137" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="138" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="137" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="137" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="137" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="137" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="138" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="138" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="138" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="139" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="139" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="138" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="138" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="138" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="139" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="138" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="138" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="138" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="138" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="139" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="139" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="139" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="140" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="140" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="139" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="139" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="139" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="140" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="139" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="139" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="139" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="139" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="140" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="140" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="140" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="140" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="141" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="141" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="140" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="140" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="140" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="141" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="140" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="140" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="140" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="140" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="141" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="141" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="141" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="142" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="142" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="141" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="141" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="141" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="142" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="141" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="141" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="141" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="141" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="142" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="142" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="142" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="143" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="143" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="142" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="142" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="142" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="143" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="142" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="142" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="142" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="142" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="143" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="143" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="143" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="144" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="144" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="143" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="143" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="143" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="144" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="143" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="143" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="143" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="143" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="144" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="144" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="144" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="145" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="145" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="144" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="144" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="144" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="145" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="144" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="144" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="144" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="144" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="145" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="145" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="145" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="146" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="146" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="145" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="145" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="145" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="146" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="145" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="145" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="145" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="145" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="146" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="146" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="146" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="147" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="147" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="146" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="146" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="146" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="147" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="146" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="146" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="146" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="146" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="147" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="147" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="147" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="148" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="148" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="147" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="147" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="147" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="148" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="147" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="147" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="147" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="147" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="148" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="148" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="148" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="149" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="149" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="148" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="148" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="148" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="149" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="148" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="148" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="148" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="148" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="149" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="149" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="149" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="150" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="150" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="149" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="149" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="149" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="150" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="149" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="149" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="149" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="149" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="150" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="150" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="150" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="151" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="151" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="150" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="150" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="150" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="151" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="150" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="150" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="150" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="150" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="151" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="151" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="151" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="152" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="152" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="151" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="151" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="151" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="152" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="151" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="151" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="151" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="151" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="152" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="152" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="152" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="153" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="153" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="152" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="152" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="152" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="153" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="152" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="152" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="152" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="152" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="153" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="153" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="153" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="154" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="154" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="153" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="153" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="153" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="154" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="153" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="153" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="153" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="153" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="154" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="154" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="154" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="155" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="155" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="154" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="154" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="154" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="155" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="154" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="154" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="154" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="154" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="155" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="155" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="155" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="156" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="156" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="155" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="155" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="155" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="156" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="155" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="155" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="155" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="155" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="156" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="156" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="156" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="157" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="157" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="156" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="156" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="156" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="157" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="156" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="156" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="156" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="156" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="157" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="157" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="157" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="158" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="158" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="157" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="157" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="157" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="158" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="157" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="157" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="157" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="157" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="158" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="158" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="158" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="159" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="159" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="158" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="158" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="158" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="159" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="158" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="158" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="158" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="158" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="159" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="159" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="159" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="160" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="160" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="159" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="159" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="159" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="160" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="159" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="159" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="159" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="159" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="160" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="160" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="160" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="161" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="161" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="160" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="160" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="160" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="161" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="160" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="160" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="160" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="160" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="161" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="161" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="161" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="162" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="162" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="161" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="161" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="161" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="162" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="161" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="161" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="161" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="161" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="162" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="162" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="162" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="163" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="163" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="162" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="162" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="162" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="163" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="162" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="162" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="162" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="162" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="163" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="163" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="163" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="164" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="164" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="163" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="163" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="163" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="164" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="163" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="163" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="163" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="163" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="164" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="164" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="164" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="165" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="165" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="164" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="164" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="164" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="165" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="164" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="164" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="164" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="164" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="165" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="165" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="165" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="166" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="166" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="165" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="165" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="165" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="166" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="165" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="165" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="165" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="165" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="166" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="166" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="166" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="167" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="167" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="166" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="166" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="166" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="167" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="166" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="166" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="166" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="166" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="167" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="167" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="167" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="168" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="168" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="167" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="167" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="167" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="168" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="167" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="167" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="167" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="167" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="168" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="168" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="168" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="169" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="169" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="168" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="168" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="168" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="169" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="168" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="168" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="168" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="168" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="169" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="169" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="169" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="170" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="170" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="169" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="169" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="169" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="170" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="169" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="169" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="169" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="169" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="170" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="170" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="170" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="171" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="171" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="170" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="170" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="170" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="171" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="170" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="170" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="170" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="170" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="171" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="171" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="171" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="172" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="172" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="171" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="171" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="171" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="172" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="171" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="171" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="171" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="171" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="172" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="172" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="172" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="173" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="173" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="172" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="172" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="172" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="173" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="172" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="172" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="172" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="172" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="173" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="173" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="173" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="174" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="174" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="173" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="173" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="173" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="174" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="173" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="173" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="173" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="173" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="174" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="174" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="174" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="175" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="175" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="174" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="174" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="174" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="175" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="174" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="174" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="174" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="174" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="175" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="175" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="175" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="176" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="176" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="175" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="175" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="175" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="176" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="175" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="175" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="175" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="175" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="176" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="176" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="176" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="177" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="177" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="176" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="176" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="176" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="177" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="176" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="176" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="176" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="176" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="177" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="177" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="177" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="178" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="178" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="177" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="177" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="177" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="178" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="177" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="177" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="177" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="177" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="178" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="178" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="178" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="179" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="179" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="178" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="178" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="178" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="179" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="178" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="178" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="178" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="178" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="179" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="179" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="179" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="180" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="180" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="179" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="179" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="179" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="180" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="179" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="179" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="179" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="179" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="180" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="180" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="180" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="181" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="181" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="180" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="180" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="180" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="181" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="180" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="180" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="180" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="180" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="181" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="181" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="181" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="182" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="182" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="181" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="181" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="181" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="182" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="181" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="181" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="181" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="181" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="182" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="182" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="182" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="183" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="183" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="182" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="182" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="182" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="183" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="182" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="182" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="182" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="182" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="183" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="183" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="183" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="184" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="184" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="183" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="183" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="183" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="184" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="183" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="183" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="183" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="183" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="184" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="184" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="184" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="185" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="185" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="184" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="184" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="184" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="185" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="184" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="184" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="184" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="184" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="185" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="185" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="185" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="186" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="186" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="185" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="185" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="185" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="186" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="185" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="185" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="185" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="185" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="186" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="186" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="186" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="187" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="187" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="186" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="186" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="186" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="187" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="186" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="186" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="186" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="186" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="187" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="187" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="187" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="188" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="188" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="187" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="187" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="187" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="188" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="187" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="187" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="187" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="187" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="188" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="188" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="188" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="189" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="189" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="188" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="188" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="188" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="189" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="188" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="188" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="188" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="188" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="189" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="189" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="189" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="190" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="190" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="189" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="189" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="189" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="190" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="189" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="189" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="189" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="189" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="190" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="190" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="190" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="191" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="191" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="190" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="190" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="190" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="191" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="190" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="190" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="190" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="190" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="191" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">E</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">strand</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="191" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="191" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="192" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="192" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="191" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="191" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="191" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="192" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="191" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="191" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="191" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="191" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="192" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="192" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="192" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="193" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="193" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="192" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="192" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="192" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="193" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="192" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="192" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="192" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="192" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="193" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="193" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="193" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="194" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="194" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="193" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="193" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="193" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="194" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="193" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="193" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="193" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="193" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="194" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="194" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="194" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="195" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="195" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="194" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="194" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="194" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="195" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="194" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="194" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="194" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="194" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="195" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="195" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="195" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="196" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="196" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="195" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="195" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="195" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="196" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="195" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="195" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="195" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="195" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="196" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="196" dbResName="TRP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="196" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="197" dbResName="W"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="197" dbResName="W"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="196" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="196" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="196" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="197" dbResName="W"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="196" dbResName="TRP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="196" dbResName="TRP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="196" dbResName="TRP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="196" dbResName="TRP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="197" dbResName="W" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="197" dbResName="TPO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="197" dbResName="TPO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="198" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="198" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="197" dbResName="TPO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="197" dbResName="TPO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="197" dbResName="TPO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="198" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="197" dbResName="TPO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="197" dbResName="TPO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="197" dbResName="TPO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="197" dbResName="TPO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="198" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="198" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="198" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="199" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="199" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="198" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="198" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="198" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="199" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="198" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="198" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="198" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="198" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="199" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="199" dbResName="CYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="199" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="200" dbResName="C"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="200" dbResName="C"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="199" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="199" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="199" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="200" dbResName="C"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="199" dbResName="CYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="199" dbResName="CYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="199" dbResName="CYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="199" dbResName="CYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="200" dbResName="C" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="200" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="200" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="201" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="201" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="200" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="200" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="200" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="201" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="200" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="200" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="200" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="200" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="201" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="201" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="201" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="202" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="202" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="201" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="201" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="201" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="202" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="201" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="201" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="201" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="201" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="202" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="202" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="202" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="203" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="203" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="202" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="202" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="202" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="203" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="202" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="202" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="202" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="202" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="203" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="203" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="203" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="204" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="204" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="203" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="203" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="203" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="204" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="203" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="203" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="203" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="203" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="204" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="204" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="204" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="205" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="205" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="204" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="204" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="204" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="205" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="204" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="204" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="204" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="204" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="205" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="205" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="205" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="206" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="206" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="205" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="205" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="205" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="206" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="205" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="205" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="205" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="205" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="206" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="206" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="206" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="207" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="207" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="206" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="206" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="206" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="207" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="206" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="206" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="206" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="206" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="207" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="207" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="207" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="208" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="208" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="207" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="207" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="207" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="208" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="207" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="207" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="207" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="207" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="208" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="208" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="208" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="209" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="209" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="208" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="208" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="208" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="209" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="208" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="208" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="208" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="208" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="209" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="209" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="209" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="210" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="210" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="209" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="209" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="209" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="210" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="209" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="209" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="209" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="209" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="210" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="210" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="210" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="211" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="211" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="210" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="210" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="210" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="211" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="210" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="210" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="210" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="210" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="211" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="211" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="211" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="212" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="212" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="211" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="211" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="211" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="212" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="211" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="211" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="211" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="211" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="212" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="212" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="212" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="213" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="213" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="212" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="212" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="212" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="213" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="212" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="212" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="212" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="212" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="213" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="213" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="213" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="214" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="214" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="213" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="213" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="213" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="214" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="213" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="213" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="213" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="213" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="214" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="214" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="214" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="215" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="215" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="214" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="214" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="214" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="215" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="214" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="214" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="214" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="214" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="215" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="215" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="215" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="216" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="216" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="215" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="215" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="215" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="216" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="215" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="215" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="215" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="215" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="216" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="216" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="216" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="217" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="217" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="216" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="216" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="216" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="217" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="216" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="216" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="216" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="216" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="217" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="217" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="217" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="218" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="218" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="217" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="217" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="217" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="218" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="217" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="217" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="217" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="217" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="218" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="218" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="218" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="219" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="219" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="218" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="218" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="218" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="219" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="218" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="218" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="218" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="218" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="219" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="219" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="219" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="220" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="220" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="219" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="219" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="219" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="220" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="219" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="219" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="219" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="219" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="220" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="220" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="220" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="221" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="221" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="220" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="220" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="220" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="221" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="220" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="220" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="220" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="220" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="221" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="221" dbResName="TRP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="221" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="222" dbResName="W"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="222" dbResName="W"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="221" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="221" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="221" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="222" dbResName="W"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="221" dbResName="TRP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="221" dbResName="TRP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="221" dbResName="TRP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="221" dbResName="TRP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="222" dbResName="W" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="222" dbResName="TRP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="222" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="223" dbResName="W"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="223" dbResName="W"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="222" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="222" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="222" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="223" dbResName="W"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="222" dbResName="TRP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="222" dbResName="TRP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="222" dbResName="TRP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="222" dbResName="TRP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="223" dbResName="W" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="223" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="223" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="224" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="224" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="223" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="223" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="223" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="224" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="223" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="223" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="223" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="223" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="224" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="224" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="224" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="225" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="225" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="224" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="224" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="224" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="225" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="224" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="224" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="224" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="224" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="225" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="225" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="225" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="226" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="226" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="225" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="225" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="225" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="226" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="225" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="225" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="225" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="225" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="226" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="226" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="226" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="227" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="227" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="226" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="226" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="226" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="227" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="226" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="226" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="226" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="226" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="227" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="227" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="227" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="228" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="228" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="227" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="227" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="227" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="228" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="227" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="227" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="227" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="227" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="228" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="228" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="228" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="229" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="229" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="228" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="228" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="228" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="229" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="228" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="228" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="228" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="228" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="229" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="229" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="229" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="230" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="230" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="229" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="229" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="229" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="230" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="229" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="229" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="229" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="229" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="230" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="230" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="230" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="231" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="231" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="230" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="230" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="230" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="231" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="230" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="230" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="230" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="230" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="231" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="231" dbResName="MET">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="231" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="232" dbResName="M"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="232" dbResName="M"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="231" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="231" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="231" dbResName="MET" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="232" dbResName="M"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="231" dbResName="MET" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="231" dbResName="MET" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="231" dbResName="MET" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="231" dbResName="MET" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="232" dbResName="M" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="232" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="232" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="233" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="233" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="232" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="232" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="232" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="233" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="232" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="232" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="232" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="232" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="233" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="233" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="233" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="234" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="234" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="233" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="233" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="233" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="234" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="233" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="233" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="233" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="233" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="234" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="234" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="234" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="235" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="235" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="234" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="234" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="234" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="235" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="234" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="234" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="234" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="234" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="235" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="235" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="235" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="236" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="236" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="235" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="235" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="235" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="236" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="235" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="235" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="235" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="235" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="236" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="236" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="236" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="237" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="237" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="236" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="236" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="236" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="237" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="236" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="236" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="236" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="236" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="237" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="237" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="237" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="238" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="238" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="237" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="237" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="237" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="238" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="237" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="237" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="237" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="237" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="238" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="238" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="238" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="239" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="239" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="238" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="238" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="238" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="239" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="238" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="238" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="238" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="238" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="239" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="239" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="239" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="240" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="240" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="239" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="239" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="239" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="240" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="239" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="239" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="239" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="239" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="240" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="240" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="240" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="241" dbResName="A"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="241" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="240" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="240" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="240" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="241" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="240" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="240" dbResName="ALA" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="240" dbResName="ALA" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="240" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="241" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="241" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="241" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="242" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="242" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="241" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="241" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="241" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="242" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="241" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="241" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="241" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="241" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="242" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="242" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="242" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="243" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="243" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="242" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="242" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="242" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="243" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="242" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="242" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="242" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="242" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="243" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="243" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="243" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="244" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="244" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="243" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="243" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="243" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="244" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="243" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="243" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="243" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="243" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="244" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="244" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="244" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="245" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="245" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="244" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="244" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="244" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="245" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="244" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="244" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="244" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="244" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="245" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="245" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="245" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="246" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="246" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="245" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="245" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="245" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="246" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="245" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="245" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="245" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="245" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="246" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="246" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="246" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="247" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="247" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="246" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="246" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="246" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="247" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="246" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="246" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="246" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="246" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="247" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="247" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="247" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="248" dbResName="Y"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="248" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="247" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="247" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="247" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="248" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="247" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="247" dbResName="TYR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="247" dbResName="TYR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="247" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="248" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="248" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="248" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="249" dbResName="E"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="249" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="248" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="248" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="248" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="249" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="248" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="248" dbResName="GLU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="248" dbResName="GLU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="248" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="249" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="249" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="249" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="250" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="250" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="249" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="249" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="249" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="250" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="249" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="249" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="249" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="249" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="250" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="250" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="250" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="251" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="251" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="250" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="250" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="250" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="251" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="250" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="250" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="250" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="250" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="251" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="251" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="251" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="252" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="252" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="251" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="251" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="251" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="252" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="251" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="251" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="251" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="251" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="252" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="252" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="252" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="253" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="253" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="252" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="252" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="252" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="253" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="252" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="252" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="252" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="252" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="253" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="253" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="253" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="254" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="254" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="253" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="253" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="253" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="254" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="253" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="253" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="253" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="253" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="254" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="254" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="254" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="255" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="255" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="254" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="254" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="254" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="255" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="254" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="254" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="254" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="254" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="255" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="255" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="255" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="256" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="256" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="255" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="255" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="255" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="256" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="255" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="255" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="255" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="255" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="256" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="256" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="256" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="257" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="257" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="256" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="256" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="256" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="257" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="256" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="256" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="256" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="256" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="257" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="257" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="257" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="258" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="258" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="257" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="257" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="257" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="258" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="257" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="257" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="257" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="257" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="258" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="258" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="258" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="259" dbResName="P"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="259" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="258" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="258" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="258" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="259" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="258" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="258" dbResName="PRO" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="258" dbResName="PRO" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="258" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="259" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="259" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="259" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="260" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="260" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="259" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="259" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="259" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="260" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="259" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="259" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="259" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="259" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="260" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="260" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="260" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="261" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="261" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="260" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="260" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="260" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="261" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="260" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="260" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="260" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="260" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="261" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="261" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="261" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="262" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="262" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="261" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="261" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="261" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="262" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="261" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="261" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="261" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="261" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="262" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="262" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="262" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="263" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="263" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="262" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="262" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="262" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="263" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="262" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="262" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="262" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="262" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="263" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="263" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="263" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="264" dbResName="S"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="264" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="263" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="263" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="263" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="264" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="263" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="263" dbResName="SER" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="263" dbResName="SER" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="263" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="264" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="264" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="264" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="265" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="265" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="264" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="264" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="264" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="265" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="264" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="264" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="264" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="264" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="265" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="265" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="265" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="266" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="266" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="265" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="265" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="265" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="266" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="265" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="265" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="265" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="265" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="266" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="266" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="266" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="267" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="267" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="266" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="266" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="266" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="267" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="266" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="266" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="266" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="266" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="267" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="267" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="267" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="268" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="268" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="267" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="267" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="267" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="268" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="267" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="267" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="267" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="267" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="268" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="268" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="268" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="269" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="269" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="268" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="268" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="268" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="269" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="268" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="268" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="268" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="268" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="269" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="269" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="269" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="270" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="270" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="269" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="269" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="269" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="270" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="269" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="269" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="269" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="269" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="270" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="270" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="270" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="271" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="271" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="270" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="270" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="270" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="271" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="270" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="270" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="270" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="270" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="271" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="271" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="271" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="272" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="272" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="271" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="271" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="271" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="272" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="271" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="271" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="271" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="271" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="272" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="272" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="272" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="273" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="273" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="272" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="272" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="272" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="273" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="272" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="272" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="272" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="272" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="273" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="273" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="273" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="274" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="274" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="273" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="273" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="273" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="274" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="273" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="273" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="273" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="273" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="274" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="274" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="274" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="275" dbResName="Q"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="275" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="274" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="274" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="274" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="275" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="274" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="274" dbResName="GLN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="274" dbResName="GLN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="274" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="275" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="275" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="275" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="276" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="276" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="275" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="275" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="275" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="276" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="275" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="275" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="275" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="275" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="276" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="276" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="276" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="277" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="277" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="276" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="276" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="276" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="277" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="276" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="276" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="276" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="276" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="277" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="277" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="277" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="278" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="278" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="277" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="277" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="277" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="278" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="277" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="277" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="277" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="277" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="278" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="278" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="278" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="279" dbResName="T"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="279" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="278" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="278" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="278" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="279" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="278" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="278" dbResName="THR" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="278" dbResName="THR" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="278" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="279" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="279" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="279" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="280" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="280" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="279" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="279" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="279" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="280" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="279" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="279" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="279" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="279" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="280" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="280" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="280" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="281" dbResName="R"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="281" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="280" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="280" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="280" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="281" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="280" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="280" dbResName="ARG" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="280" dbResName="ARG" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="280" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="281" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="281" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="281" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="282" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="282" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="281" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="281" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="281" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="282" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="281" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="281" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="281" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="281" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="282" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="282" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="282" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="283" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="283" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="282" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="282" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="282" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="283" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="282" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="282" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="282" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="282" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="283" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="283" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="283" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="284" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="284" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="283" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="283" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="283" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="284" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="283" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="283" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="283" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="283" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="284" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="284" dbResName="LEU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="284" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="285" dbResName="L"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="285" dbResName="L"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="284" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="284" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="284" dbResName="LEU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="285" dbResName="L"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="284" dbResName="LEU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="284" dbResName="LEU" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="284" dbResName="LEU" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="284" dbResName="LEU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="285" dbResName="L" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="285" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="285" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="286" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="286" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="285" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="285" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="285" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="286" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="285" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="285" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="285" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="285" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="286" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="286" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="286" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="287" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="287" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="286" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="286" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="286" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="287" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="286" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="286" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="286" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="286" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="287" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="287" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="287" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="288" dbResName="G"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="288" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="287" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="287" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="287" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="288" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="287" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="287" dbResName="GLY" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="287" dbResName="GLY" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="287" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="288" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="288" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="288" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="289" dbResName="V"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="289" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="288" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="288" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="288" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="289" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="288" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="288" dbResName="VAL" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="288" dbResName="VAL" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="288" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="289" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="289" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="289" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="290" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="290" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="289" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="289" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="289" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="290" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="289" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="289" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="289" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="289" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="290" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="290" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="290" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="291" dbResName="D"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="291" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="290" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="290" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="290" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="291" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="290" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="290" dbResName="ASP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="290" dbResName="ASP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="290" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="291" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="291" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="291" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="292" dbResName="I"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="292" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="291" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="291" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="291" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="292" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="291" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="291" dbResName="ILE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="291" dbResName="ILE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="291" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="292" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="292" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="292" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="293" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="293" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="292" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="292" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="292" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="293" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="292" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="292" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="292" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="292" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="293" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="293" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="293" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="294" dbResName="N"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="294" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="293" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="293" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="293" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="294" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="293" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="293" dbResName="ASN" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="293" dbResName="ASN" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="293" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="294" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="294" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="294" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="295" dbResName="H"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="295" dbResName="H"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="294" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="294" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="294" dbResName="HIS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="295" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="294" dbResName="HIS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="294" dbResName="HIS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="294" dbResName="HIS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="294" dbResName="HIS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="295" dbResName="H" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="295" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="295" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="296" dbResName="K"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="296" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="295" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="295" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="295" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="296" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="295" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="295" dbResName="LYS" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="295" dbResName="LYS" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="295" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="296" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="296" dbResName="TRP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="296" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="297" dbResName="W"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="297" dbResName="W"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="296" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="296" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="296" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="297" dbResName="W"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="296" dbResName="TRP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="296" dbResName="TRP" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="296" dbResName="TRP" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="296" dbResName="TRP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="297" dbResName="W" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="297" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="297" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="298" dbResName="F"/>
+          <crossRefDb dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" dbResNum="298" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="297" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="297" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="297" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="298" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="297" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="297" dbResName="PHE" dbChainId="E" dbEvidence="PF00069"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719" dbResNum="297" dbResName="PHE" dbChainId="E" dbEvidence="SM00220"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="297" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="298" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="298" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="298" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="299" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="298" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="298" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="298" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="299" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="298" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="298" dbResName="ALA" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="298" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="299" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="299" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="299" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="300" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="299" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="299" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="299" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="300" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="299" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="299" dbResName="THR" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="299" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="300" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="300" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="300" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="301" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="300" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="300" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="300" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="301" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="300" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="300" dbResName="THR" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="300" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="301" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="301" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="301" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="302" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="301" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="301" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="301" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="302" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="301" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="301" dbResName="ASP" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="301" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="302" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="302" dbResName="TRP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="302" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="303" dbResName="W"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="302" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="302" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="302" dbResName="TRP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="303" dbResName="W"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="302" dbResName="TRP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="302" dbResName="TRP" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="302" dbResName="TRP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="303" dbResName="W" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="303" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="303" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="304" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="303" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="303" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="303" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="304" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="303" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="303" dbResName="ILE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="303" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="304" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="304" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="304" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="305" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="304" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="304" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="304" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="305" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="304" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="304" dbResName="ALA" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="304" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="305" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="305" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="305" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="306" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="305" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="305" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="305" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="306" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="305" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="305" dbResName="ILE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="305" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="306" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="306" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="306" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="307" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="306" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="306" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="306" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="307" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="306" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="306" dbResName="TYR" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="306" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="307" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="307" dbResName="GLN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="307" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="308" dbResName="Q"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="307" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="307" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="307" dbResName="GLN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="308" dbResName="Q"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="307" dbResName="GLN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="307" dbResName="GLN" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="307" dbResName="GLN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="308" dbResName="Q" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="308" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="308" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="309" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="308" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="308" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="308" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="309" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="308" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="308" dbResName="ARG" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="308" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="309" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="309" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="309" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="310" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="309" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="309" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="309" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="310" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="309" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="309" dbResName="LYS" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="309" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="310" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="310" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="310" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="311" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="310" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="310" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="310" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="311" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="310" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="310" dbResName="VAL" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="310" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="311" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="311" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="311" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="312" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="311" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="311" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="311" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="312" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="311" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="311" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="311" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="312" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="312" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="312" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="313" dbResName="A"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="312" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="312" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="312" dbResName="ALA" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="313" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="312" dbResName="ALA" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="312" dbResName="ALA" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="312" dbResName="ALA" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="313" dbResName="A" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="313" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="313" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="314" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="313" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="313" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="313" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="314" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="313" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="313" dbResName="PRO" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="313" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="314" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="314" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="314" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="315" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="314" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="314" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="314" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="315" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="314" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="314" dbResName="PHE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="314" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="315" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="315" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="315" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="316" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="315" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="315" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="315" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="316" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="315" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="315" dbResName="ILE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="315" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="316" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="316" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="316" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="317" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="316" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="316" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="316" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="317" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="316" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="316" dbResName="PRO" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="316" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="317" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="317" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="317" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="318" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10" dbResNum="317" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="317" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="317" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="318" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="317" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="317" dbResName="LYS" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="317" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="318" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="318" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="318" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="319" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="318" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="318" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="318" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="319" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="318" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="318" dbResName="PHE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="318" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="319" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="319" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="319" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="320" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="319" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="319" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="319" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="320" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="319" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="319" dbResName="LYS" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="319" dbResName="LYS" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="320" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="320" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="320" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="321" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="320" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="320" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="320" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="321" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="320" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="320" dbResName="GLY" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="320" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="321" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="321" dbResName="PRO">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="321" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="322" dbResName="P"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="321" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="321" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="321" dbResName="PRO" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="322" dbResName="P"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="321" dbResName="PRO" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="321" dbResName="PRO" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="321" dbResName="PRO" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="322" dbResName="P" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="322" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="322" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="323" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="322" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="322" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="322" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="323" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="322" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="322" dbResName="GLY" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="322" dbResName="GLY" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="323" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="323" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="323" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="324" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="323" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="323" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="323" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="324" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="323" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="323" dbResName="ASP" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="323" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="324" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="324" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="324" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="325" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="324" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="324" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="324" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="325" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="324" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="324" dbResName="THR" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="324" dbResName="THR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="325" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="325" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="325" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="326" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="325" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="325" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="325" dbResName="SER" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="326" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="325" dbResName="SER" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="325" dbResName="SER" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="325" dbResName="SER" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="326" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="326" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="326" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="327" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="326" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="326" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="326" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="327" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="326" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="326" dbResName="ASN" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="326" dbResName="ASN" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="327" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="327" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="327" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="328" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="327" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="327" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="327" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="328" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="327" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="327" dbResName="PHE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="327" dbResName="PHE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="328" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="328" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="328" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="329" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="328" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="328" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="328" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="329" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="328" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="328" dbResName="ASP" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="328" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="329" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="329" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="329" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="330" dbResName="D"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="329" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="329" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="329" dbResName="ASP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="330" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="329" dbResName="ASP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="329" dbResName="ASP" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="329" dbResName="ASP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="330" dbResName="D" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="330" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="330" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="331" dbResName="Y"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="330" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="330" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="330" dbResName="TYR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="331" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="330" dbResName="TYR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="330" dbResName="TYR" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="330" dbResName="TYR" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="331" dbResName="Y" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="331" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="331" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="332" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="331" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="331" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="331" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="332" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="331" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="331" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="331" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="332" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="332" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="332" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="333" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="332" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="332" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="332" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="333" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="332" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="332" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="332" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="333" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="333" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="333" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="334" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="333" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="333" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="333" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="334" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="333" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="333" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="333" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="334" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="334" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="334" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="335" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="334" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="334" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="334" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="335" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="334" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="334" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="334" dbResName="GLU" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="335" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="335" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="335" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="336" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="335" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="335" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="335" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="336" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="335" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="335" dbResName="ILE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="335" dbResName="ILE" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="336" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="336" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="336" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="337" dbResName="R"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="336" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="336" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="336" dbResName="ARG" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="337" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="336" dbResName="ARG" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="336" dbResName="ARG" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="336" dbResName="ARG" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="337" dbResName="R" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="337" dbResName="VAL">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="337" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="338" dbResName="V"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="337" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="337" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="337" dbResName="VAL" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="338" dbResName="V"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="337" dbResName="VAL" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="337" dbResName="VAL" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="337" dbResName="VAL" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="338" dbResName="V" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="338" dbResName="SEP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="338" dbResName="SEP" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="339" dbResName="S"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="338" dbResName="SEP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="338" dbResName="SEP" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="338" dbResName="SEP" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="339" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="338" dbResName="SEP" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="338" dbResName="SEP" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009" dbResNum="338" dbResName="SEP" dbChainId="E" dbEvidence="SSF56112"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="339" dbResName="S" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="339" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="339" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="340" dbResName="I"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="339" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="339" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="339" dbResName="ILE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="340" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="339" dbResName="ILE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="339" dbResName="ILE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="340" dbResName="I" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="340" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="340" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="341" dbResName="N"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="340" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="340" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="340" dbResName="ASN" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="341" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="340" dbResName="ASN" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="340" dbResName="ASN" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="341" dbResName="N" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="341" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="341" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="342" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="341" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="341" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="341" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="342" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="341" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="341" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="342" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="342" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="342" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="343" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="342" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="342" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="342" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="343" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="342" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="342" dbResName="LYS" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="343" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="343" dbResName="CYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="343" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="344" dbResName="C"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="343" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="343" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="343" dbResName="CYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="344" dbResName="C"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="343" dbResName="CYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="343" dbResName="CYS" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="344" dbResName="C" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="344" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="344" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="345" dbResName="G"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="344" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="344" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="344" dbResName="GLY" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="345" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="344" dbResName="GLY" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="344" dbResName="GLY" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="345" dbResName="G" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="345" dbResName="LYS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="345" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="346" dbResName="K"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="345" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="345" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="345" dbResName="LYS" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="346" dbResName="K"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="345" dbResName="LYS" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="345" dbResName="LYS" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="346" dbResName="K" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="346" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="346" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="347" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="346" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="346" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="346" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="347" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="346" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="346" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="347" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="347" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="347" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="348" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="347" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="347" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="347" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="348" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="347" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="347" dbResName="PHE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="348" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="348" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="348" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="349" dbResName="T"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="348" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="348" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="348" dbResName="THR" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="349" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="348" dbResName="THR" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="348" dbResName="THR" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="349" dbResName="T" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="349" dbResName="GLU">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="349" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="350" dbResName="E"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="349" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="349" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="349" dbResName="GLU" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="350" dbResName="E"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="349" dbResName="GLU" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="349" dbResName="GLU" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="350" dbResName="E" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="350" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="350" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" dbResNum="351" dbResName="F"/>
+          <crossRefDb dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20" dbResNum="350" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629" dbResNum="350" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503" dbResNum="350" dbResName="PHE" dbChainId="E"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="351" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035" dbResNum="350" dbResName="PHE" dbChainId="E" dbEvidence="PTHR24353:SF82"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961" dbResNum="350" dbResName="PHE" dbChainId="E" dbEvidence="SM00133"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbResNum="351" dbResName="F" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+      </listResidue>
+      <listMapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbChainId="E" start="1" end="350"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P05132" start="2" end="351"/>
+          <dbDetail dbSource="UniProt" property="secondaryId">KAPCA_MOUSE</dbDetail>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0000166" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0000287" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0001669" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0001669" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0001707" dbEvidence="IGI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0001843" dbEvidence="IGI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004672" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004674" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004679" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004691" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004712" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004712" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005515" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005524" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005524" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005524" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005524" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005524" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005524" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="IBA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005634" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005654" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005654" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005654" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005654" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005737" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005739" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005739" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005739" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005794" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005813" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005813" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="TAS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005829" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005886" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005886" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005886" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005929" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005930" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005930" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005952" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005952" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005952" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0005952" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006397" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006397" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006468" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0008284" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0010737" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0010737" dbEvidence="IBA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016020" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016020" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016020" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016020" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016020" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016301" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016310" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016607" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016607" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0016740" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0017137" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018105" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018105" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018105" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018105" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018105" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018105" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0018107" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0019901" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0019901" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0019901" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0019904" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0030145" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031410" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031514" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031514" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031588" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031594" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031625" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0031625" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0032991" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034237" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034237" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034237" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034237" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034237" dbEvidence="IBA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034237" dbEvidence="IPI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034605" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034605" dbEvidence="ISS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0034605" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0036126" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0042995" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0043005" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0043197" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0043457" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0044853" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0044853" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0044877" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0045171" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0045171" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0045171" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0045667" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0045667" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0046777" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0046777" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0046827" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0048240" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0048471" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0048471" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0048471" dbEvidence="ISS"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0048471" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0048792" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0050804" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0051447" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0051966" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0061136" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0061136" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0070613" dbEvidence="IGI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0071158" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0071333" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0071333" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0071333" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0071374" dbEvidence="IMP"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0097225" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0097546" dbEvidence="IDA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0098793" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:1901621" dbEvidence="IGI"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:2000810" dbEvidence="ISO"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:2000810" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="EC" dbCoordSys="UniProt" dbAccessionId="2.7.11.11"/>
+        </mapRegion>
+        <mapRegion start="112" end="139">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212132"/>
+        </mapRegion>
+        <mapRegion start="139" end="181">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212136"/>
+        </mapRegion>
+        <mapRegion start="182" end="213">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212131"/>
+        </mapRegion>
+        <mapRegion start="255" end="309">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000497229"/>
+        </mapRegion>
+        <mapRegion start="1" end="15">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000270752"/>
+        </mapRegion>
+        <mapRegion start="310" end="350">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000900268"/>
+        </mapRegion>
+        <mapRegion start="15" end="35">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000481041"/>
+        </mapRegion>
+        <mapRegion start="214" end="254">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000483638"/>
+        </mapRegion>
+        <mapRegion start="36" end="78">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000469392"/>
+        </mapRegion>
+        <mapRegion start="79" end="111">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000005469" dbTranscriptId="ENSMUST00000005606" dbTranslationId="ENSMUSP00000005606" dbExonId="ENSMUSE00000212134"/>
+        </mapRegion>
+        <mapRegion start="2" end="350">
+          <db dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR039035"/>
+        </mapRegion>
+        <mapRegion start="298" end="350">
+          <db dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000961"/>
+        </mapRegion>
+        <mapRegion start="44" end="297">
+          <db dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719"/>
+        </mapRegion>
+        <mapRegion start="43" end="297">
+          <db dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR000719"/>
+        </mapRegion>
+        <mapRegion start="27" end="338">
+          <db dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR011009"/>
+        </mapRegion>
+        <mapRegion start="15" end="32">
+          <db dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10"/>
+        </mapRegion>
+        <mapRegion start="33" end="126">
+          <db dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20"/>
+        </mapRegion>
+        <mapRegion start="127" end="317">
+          <db dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="1.10.510.10"/>
+        </mapRegion>
+        <mapRegion start="318" end="350">
+          <db dbSource="CATH" dbCoordSys="PDBresnum" dbAccessionId="3.30.200.20"/>
+        </mapRegion>
+        <mapRegion start="1" end="350">
+          <db dbSource="SCOP" dbCoordSys="PDBresnum" dbAccessionId="41629"/>
+        </mapRegion>
+        <mapRegion start="15" end="350">
+          <db dbSource="SCOP2B" dbCoordSys="PDBresnum" dbAccessionId="SF-DOMID:8040503"/>
+        </mapRegion>
+        <mapRegion start="43" end="297">
+          <db dbSource="Pfam" dbCoordSys="UniProt" dbAccessionId="PF00069" coverage="1"/>
+        </mapRegion>
+      </listMapRegion>
+    </segment>
+  </entity>
+  <entity type="protein" entityId="B">
+    <segment segId="1atp_B_1_20" start="1" end="20">
+      <listResidue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="1" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="5" dbResName="THR" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="6" dbResName="T"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="6" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="5" dbResName="THR" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="6" dbResName="T" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="6" dbResName="T" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="2" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="6" dbResName="THR" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="7" dbResName="T"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="7" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="6" dbResName="THR" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="7" dbResName="T" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="7" dbResName="T" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="3" dbResName="TYR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="7" dbResName="TYR" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="8" dbResName="Y"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="8" dbResName="Y"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="7" dbResName="TYR" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="8" dbResName="Y" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="8" dbResName="Y" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="4" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="8" dbResName="ALA" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="9" dbResName="A"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="9" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="8" dbResName="ALA" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="9" dbResName="A" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="9" dbResName="A" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="5" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="9" dbResName="ASP" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="10" dbResName="D"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="10" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="9" dbResName="ASP" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="10" dbResName="D" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="10" dbResName="D" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="6" dbResName="PHE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="10" dbResName="PHE" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="11" dbResName="F"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="11" dbResName="F"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="10" dbResName="PHE" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="11" dbResName="F" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="11" dbResName="F" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="7" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="11" dbResName="ILE" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="12" dbResName="I"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="12" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="11" dbResName="ILE" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="12" dbResName="I" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="12" dbResName="I" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="8" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="12" dbResName="ALA" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="13" dbResName="A"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="13" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="12" dbResName="ALA" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="13" dbResName="A" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="13" dbResName="A" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">H</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">helix</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="9" dbResName="SER">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="13" dbResName="SER" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="14" dbResName="S"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="14" dbResName="S"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="13" dbResName="SER" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="14" dbResName="S" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="14" dbResName="S" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="10" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="14" dbResName="GLY" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="15" dbResName="G"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="15" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="14" dbResName="GLY" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="15" dbResName="G" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="15" dbResName="G" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="11" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="15" dbResName="ARG" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="16" dbResName="R"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="16" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="15" dbResName="ARG" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="16" dbResName="R" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="16" dbResName="R" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="12" dbResName="THR">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="16" dbResName="THR" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="17" dbResName="T"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="17" dbResName="T"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="16" dbResName="THR" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="17" dbResName="T" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="17" dbResName="T" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="13" dbResName="GLY">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="17" dbResName="GLY" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="18" dbResName="G"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="18" dbResName="G"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="17" dbResName="GLY" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="18" dbResName="G" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="18" dbResName="G" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="14" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="18" dbResName="ARG" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="19" dbResName="R"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="19" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="18" dbResName="ARG" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="19" dbResName="R" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="19" dbResName="R" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="15" dbResName="ARG">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="19" dbResName="ARG" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="20" dbResName="R"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="20" dbResName="R"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="19" dbResName="ARG" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="20" dbResName="R" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="20" dbResName="R" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="16" dbResName="ASN">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="20" dbResName="ASN" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="21" dbResName="N"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="21" dbResName="N"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="20" dbResName="ASN" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="21" dbResName="N" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="21" dbResName="N" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="17" dbResName="ALA">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="21" dbResName="ALA" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="22" dbResName="A"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="22" dbResName="A"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="21" dbResName="ALA" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="22" dbResName="A" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="22" dbResName="A" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="18" dbResName="ILE">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="22" dbResName="ILE" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="23" dbResName="I"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="23" dbResName="I"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="22" dbResName="ILE" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="23" dbResName="I" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="23" dbResName="I" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="19" dbResName="HIS">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="23" dbResName="HIS" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="24" dbResName="H"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="24" dbResName="H"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="23" dbResName="HIS" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="24" dbResName="H" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="24" dbResName="H" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+        <residue dbSource="PDBe" dbCoordSys="PDBe" dbResNum="20" dbResName="ASP">
+          <crossRefDb dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbResNum="24" dbResName="ASP" dbChainId="I"/>
+          <crossRefDb dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" dbResNum="25" dbResName="D"/>
+          <crossRefDb dbSource="NCBI" dbCoordSys="UniProt" dbAccessionId="10090" dbResNum="25" dbResName="D"/>
+          <crossRefDb dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171" dbResNum="24" dbResName="ASP" dbChainId="I" dbEvidence="PF02827"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="25" dbResName="D" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+          <crossRefDb dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbResNum="25" dbResName="D" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+          <residueDetail dbSource="PDBe" property="codeSecondaryStructure">T</residueDetail>
+          <residueDetail dbSource="PDBe" property="nameSecondaryStructure">loop</residueDetail>
+        </residue>
+      </listResidue>
+      <listMapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="PDB" dbCoordSys="PDBresnum" dbAccessionId="1atp" dbChainId="I" start="1" end="20"/>
+        </mapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="UniProt" dbCoordSys="UniProt" dbAccessionId="P63248" start="6" end="25"/>
+          <dbDetail dbSource="UniProt" property="secondaryId">IPKA_MOUSE</dbDetail>
+        </mapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0004862" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="GO" dbCoordSys="UniProt" dbAccessionId="GO:0006469" dbEvidence="IEA"/>
+        </mapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbTranscriptId="ENSMUST00000193330" dbTranslationId="ENSMUSP00000141466" dbExonId="ENSMUSE00001380029"/>
+        </mapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="Ensembl" dbCoordSys="UniProt" dbAccessionId="ENSMUSG00000027499" dbTranscriptId="ENSMUST00000028999" dbTranslationId="ENSMUSP00000028999" dbExonId="ENSMUSE00001380029"/>
+        </mapRegion>
+        <mapRegion start="1" end="20">
+          <db dbSource="InterPro" dbCoordSys="PDBresnum" dbAccessionId="IPR004171"/>
+        </mapRegion>
+      </listMapRegion>
+    </segment>
+  </entity>
+</entry>


### PR DESCRIPTION
This MR fixes the function `pdb.map_uniprot_resnum_to_pdb`.
Previously it read chains with the assumption that chain A == entity A. 
If chains IDs in the PDB start later in the alphabet, this caused issues (i.e. PDB ID: 1atp chain I)

Now the code reads unique chains in the SIFTs file.
And then loops through them alphabetically. so that the first chain -> A, second -> B. etc.

This is a precursor to my open issue (https://github.com/SBRG/ssbio/issues/51). I hope its useful.

The tests pass, but I have not fixed the existing broken test in the same file (`test_download_biomol`)